### PR TITLE
Add SwapProxyHolder logic

### DIFF
--- a/contracts/exchange/FusdUsdtSwapPair.cdc
+++ b/contracts/exchange/FusdUsdtSwapPair.cdc
@@ -212,6 +212,43 @@ pub contract FusdUsdtSwapPair: FungibleToken {
     }
   }
 
+  pub resource interface SwapProxyReceiver {
+    pub fun depositSwapProxy(from: @FusdUsdtSwapPair.SwapProxy)
+  }
+
+  pub resource SwapProxyHolder: SwapProxyReceiver {
+    // holder for SwapProxy resource
+    pub var swapProxy: @FusdUsdtSwapPair.SwapProxy?
+
+    pub fun depositSwapProxy(from: @FusdUsdtSwapPair.SwapProxy) {
+      let oldSwapProxy <- self.swapProxy <- from
+
+      destroy oldSwapProxy
+    }
+
+    pub fun withdrawSwapProxy(): @FusdUsdtSwapPair.SwapProxy {
+      pre {
+        self.swapProxy != nil: "SwapProxy is not available"
+      }
+
+      let swapProxy <- self.swapProxy <- nil
+
+      return <- swapProxy!
+    }
+
+    init() {
+      self.swapProxy <- nil
+    }
+
+    destroy() {
+      destroy self.swapProxy
+    }
+  }
+
+  pub fun createSwapProxyHolder(): @FusdUsdtSwapPair.SwapProxyHolder {
+    return <- create SwapProxyHolder()
+  }
+
   pub resource Admin {
     pub fun freeze() {
       FusdUsdtSwapPair.isFrozen = true

--- a/scripts/exchange/FusdUsdtSwapPair/depositSwapProxy.cdc
+++ b/scripts/exchange/FusdUsdtSwapPair/depositSwapProxy.cdc
@@ -1,0 +1,24 @@
+import FusdUsdtSwapPair from 0xFUSDUSDTSWAPPAIRADDRESS
+
+transaction(to: Address) {
+  let proxy: @FusdUsdtSwapPair.SwapProxy
+
+  prepare(swapContractAccount: AuthAccount) {
+    let adminRef = swapContractAccount.borrow<&FusdUsdtSwapPair.Admin>(from: /storage/fusdUsdtPairAdmin)
+      ?? panic("Could not borrow a reference to Admin")
+
+    self.proxy <- adminRef.createSwapProxy()
+  }
+
+  execute {
+    // Get the recipient's public account object
+    let recipient = getAccount(to)
+
+    let receiverRef = recipient
+      .getCapability(/public/fusdUsdtSwapProxyReceiver)
+      .borrow<&FusdUsdtSwapPair.SwapProxyHolder{FusdUsdtSwapPair.SwapProxyReceiver}>()
+			?? panic("Could not borrow receiver reference to the recipient's SwapProxyHolder")
+    
+    receiverRef.depositSwapProxy(from: <- self.proxy)
+  }
+}

--- a/scripts/exchange/FusdUsdtSwapPair/setupSwapProxyReceiver.cdc
+++ b/scripts/exchange/FusdUsdtSwapPair/setupSwapProxyReceiver.cdc
@@ -1,0 +1,15 @@
+import FusdUsdtSwapPair from 0xFUSDUSDTSWAPPAIRADDRESS
+
+transaction {
+  prepare(proxyHolder: AuthAccount) {
+    let swapProxyHolder <- FusdUsdtSwapPair.createSwapProxyHolder()
+
+    proxyHolder.save(<-swapProxyHolder, to: /storage/fusdUsdtSwapProxyHolder)
+
+    // create new receiver that marks received tokens as unlocked
+    proxyHolder.link<&FusdUsdtSwapPair.SwapProxyHolder{FusdUsdtSwapPair.SwapProxyReceiver}>(
+      /public/fusdUsdtSwapProxyReceiver,
+      target: /storage/fusdUsdtSwapProxyHolder
+    )
+  }
+}

--- a/scripts/exchange/FusdUsdtSwapPair/withdrawSwapProxy.cdc
+++ b/scripts/exchange/FusdUsdtSwapPair/withdrawSwapProxy.cdc
@@ -1,0 +1,13 @@
+import FusdUsdtSwapPair from 0xFUSDUSDTSWAPPAIRADDRESS
+
+transaction {
+  prepare(proxyHolder: AuthAccount) {
+    let swapProxyHolder = proxyHolder
+      .borrow<&FusdUsdtSwapPair.SwapProxyHolder>(from: /storage/fusdUsdtSwapProxyHolder)
+      ?? panic("Could not borrow a reference to SwapProxyHolder")
+
+    let swapProxy <- swapProxyHolder.withdrawSwapProxy()
+
+    proxyHolder.save(<-swapProxy, to: /storage/fusdUsdtSwapProxy)
+  }
+}


### PR DESCRIPTION
Add SwapProxyHolder for receiving SwapProxy resource

Account setup process:
1. [Operator] setup SwapProxyHolder
2. [Swap Admin] deposit SwapProxy to SwapProxyHolder
3. [Operator] withdraw SwapProxy from SwapProxyHolder